### PR TITLE
Use ELK's classloader, not root classloader to discover services

### DIFF
--- a/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
+++ b/plugins/org.eclipse.elk.core/src/org/eclipse/elk/core/data/LayoutMetaDataService.java
@@ -51,7 +51,11 @@ public final class LayoutMetaDataService {
      * @return  the singleton instance
      */
     public static synchronized LayoutMetaDataService getInstance() {
-        return getInstance(null);
+        Object loader = null;
+        // elkjs-exclude-start
+        loader = LayoutMetaDataService.class.getClassLoader();
+        // elkjs-exclude-end
+        return getInstance(loader);
     }
     
     /**


### PR DESCRIPTION
This will use the `LayoutMetaDataService`'s classloader to allow for cases when this JAR and other ELK JARs are loaded in dynamic classloader. 

The previous logic introduced in #789 would only work if the classes were part of the root classloader.  

Closes #1108