### PR TITLE
Use SPDX for Maven license tag

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -479,8 +479,8 @@
   <!-- The license ELK is available as. -->
   <licenses>
     <license>
-      <name>Eclipse Public License - v 2.0</name>
-      <url>http://www.eclipse.org/legal/epl-v20.html</url>
+      <name>EPL-2.0</name>
+      <url>https://www.eclipse.org/legal/epl-2.0</url>
     </license>
   </licenses>
 


### PR DESCRIPTION
That's the Maven recommendation for the license tag, because it simplifies automated evaluation of the tag in license compliance tools.

See https://maven.apache.org/pom.html#Licenses

Also update the license URL to use https and to avoid a specific file extension.