### PR TITLE
Configure Maven compiler level

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -22,6 +22,9 @@
   <!-- Define a few properties used throughout all build profiles. -->
   <properties>
     <targetJdk>11</targetJdk>
+    <maven.compiler.release>${targetJdk}</maven.compiler.release>
+    <maven.compiler.source>${targetJdk}</maven.compiler.source>
+    <maven.compiler.target>${targetJdk}</maven.compiler.target>
     <tycho-version>2.7.3</tycho-version>
     <xtext-version>2.28.0</xtext-version>
     <elk-version>${project.version}</elk-version>
@@ -309,6 +312,7 @@
           <version>${xtext-version}</version>
           <configuration>
             <outputDirectory>${basedir}/xtend-gen</outputDirectory>
+            <javaSourceVersion>${maven.compiler.release}</javaSourceVersion>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
The Maven build didn't configure any JDK target level for compilation. Neither for Java code, nor for Xtext generated code. The new properties configure the Java compiler (maven.compiler.release) and the Xtext generator (if takes its default from the maven-compiler-plugin, therefore we set source/target of the compiler, even though that looks superfluous after the release property).

Fixes #1114.