### PR TITLE
Add missing module names

### DIFF
--- a/test/org.eclipse.elk.alg.radial.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.radial.test/META-INF/MANIFEST.MF
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: org.eclipse.elk.alg.radial.test
 Bundle-Name: ELK Layout Radial Tests
 Bundle-SymbolicName: org.eclipse.elk.alg.radial.test;singleton:=true
 Bundle-Version: 0.10.0.qualifier

--- a/test/org.eclipse.elk.alg.spore.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.spore.test/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: com.google.guava;bundle-version="18.0.0",
  org.eclipse.elk.alg.common,
  org.eclipse.elk.alg.spore,
  org.junit;bundle-version="4.12.0"
+Automatic-Module-Name: org.eclipse.elk.alg.spore.test

--- a/test/org.eclipse.elk.alg.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.alg.test/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Export-Package: org.eclipse.elk.alg.test,
  org.eclipse.elk.alg.test.framework,
  org.eclipse.elk.alg.test.framework.annotations,
  org.eclipse.elk.alg.test.framework.io
+Automatic-Module-Name: org.eclipse.elk.alg.test

--- a/test/org.eclipse.elk.core.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.core.test/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Require-Bundle: com.google.guava,
  org.eclipse.elk.graph,
  org.eclipse.elk.alg.test
 Bundle-Vendor: Eclipse Modeling Project
+Automatic-Module-Name: org.eclipse.elk.core.test

--- a/test/org.eclipse.elk.graph.json.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.graph.json.test/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro
+Automatic-Module-Name: org.eclipse.elk.graph.json.test
 

--- a/test/org.eclipse.elk.graph.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.graph.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: com.google.guava,
  org.eclipse.emf.common,
  org.eclipse.elk.graph,
  org.junit;bundle-version="4.12.0"
+Automatic-Module-Name: org.eclipse.elk.graph.test

--- a/test/org.eclipse.elk.shared.test/META-INF/MANIFEST.MF
+++ b/test/org.eclipse.elk.shared.test/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle: com.google.guava,
  org.eclipse.elk.alg.radial,
  org.eclipse.elk.alg.test
 Bundle-Vendor: Eclipse Modeling Project
+Automatic-Module-Name: org.eclipse.elk.shared.test


### PR DESCRIPTION
Fixes all related warnings of PDE for Java 9 or later.

![image](https://github.com/user-attachments/assets/aacee758-c949-4fc6-8b8e-2886aa96c3f2)
