### PR TITLE
Explicitly mark all Eclipse projects as UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@ docs/content/reference/options/
 docs/content/reference/groups/
 docs/static/img_gen/
 docs/public
-org.eclipse.core.resources.prefs
 org.eclipse.m2e.core.prefs

--- a/build/.settings/org.eclipse.core.resources.prefs
+++ b/build/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/build/org.eclipse.elk.repository/.settings/org.eclipse.core.resources.prefs
+++ b/build/org.eclipse.elk.repository/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/build/org.eclipse.elk.targetplatform/.settings/org.eclipse.core.resources.prefs
+++ b/build/org.eclipse.elk.targetplatform/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/docs/.settings/org.eclipse.core.resources.prefs
+++ b/docs/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/.settings/org.eclipse.core.resources.prefs
+++ b/features/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.elk.libavoid.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.elk.libavoid.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.elk.sdk.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.elk.sdk.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.elk.ui.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.elk.ui.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.elk.alg.libavoid/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.elk.alg.libavoid/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.elk.alg.rectpacking/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.elk.alg.rectpacking/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.elk.alg.topdownpacking/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.elk.core.debug/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.elk.core.debug/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.elk.graph.json.text.ide/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.elk.graph.json.text.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.elk.graph.json.text.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.elk.graph.json.text.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.elk.graph.json.text/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.elk.graph.json.text/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/.settings/org.eclipse.core.resources.prefs
+++ b/test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.common.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.common.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.force.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.force.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.layered.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.layered.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.mrtree.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.mrtree.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.radial.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.radial.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.rectpacking.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.rectpacking.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.spore.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.spore.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/org.eclipse.elk.alg.topdown.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/org.eclipse.elk.alg.topdown.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
In older eclipse versions the default encoding of the workspace depends on the operating system. Therefore different developers may use different encodings. Explicitly set the encoding in all projects and put the related prefs files under version control to make the build reproducible.

This fixes another 25 warnings in the IDE.