### PR TITLE
Remove duplicate groupid and version

### DIFF
--- a/build/org.eclipse.elk.repository/pom.xml
+++ b/build/org.eclipse.elk.repository/pom.xml
@@ -10,7 +10,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <version>0.10.0-SNAPSHOT</version>
   <artifactId>org.eclipse.elk.repository</artifactId>
   <packaging>eclipse-repository</packaging>
   <name>Eclipse Layout Kernel Repository</name>

--- a/features/org.eclipse.elk.algorithms.feature/pom.xml
+++ b/features/org.eclipse.elk.algorithms.feature/pom.xml
@@ -15,8 +15,6 @@
     <artifactId>features</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.algorithms.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.feature/pom.xml
+++ b/features/org.eclipse.elk.feature/pom.xml
@@ -15,8 +15,6 @@
     <artifactId>features</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.gmf.feature/pom.xml
+++ b/features/org.eclipse.elk.gmf.feature/pom.xml
@@ -15,8 +15,6 @@
     <artifactId>features</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.gmf.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.graph.json.feature/pom.xml
+++ b/features/org.eclipse.elk.graph.json.feature/pom.xml
@@ -15,8 +15,6 @@
     <artifactId>features</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.json.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.graphviz.feature/pom.xml
+++ b/features/org.eclipse.elk.graphviz.feature/pom.xml
@@ -15,8 +15,6 @@
     <artifactId>features</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graphviz.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.libavoid.feature/pom.xml
+++ b/features/org.eclipse.elk.libavoid.feature/pom.xml
@@ -15,8 +15,6 @@
     <artifactId>features</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.libavoid.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.sdk.feature/pom.xml
+++ b/features/org.eclipse.elk.sdk.feature/pom.xml
@@ -17,8 +17,6 @@
     <version>0.10.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.sdk.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/org.eclipse.elk.ui.feature/pom.xml
+++ b/features/org.eclipse.elk.ui.feature/pom.xml
@@ -15,8 +15,6 @@
     <artifactId>features</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.ui.feature</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -9,9 +9,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>features</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>

--- a/plugins/org.eclipse.elk.alg.common/pom.xml
+++ b/plugins/org.eclipse.elk.alg.common/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.common</artifactId>
   <name>ELK Common Algorithms</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Common algorithms.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.disco.debug/pom.xml
+++ b/plugins/org.eclipse.elk.alg.disco.debug/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.disco.debug</artifactId>
   <name>ELK DisCo Debugging Utilities</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.alg.disco/pom.xml
+++ b/plugins/org.eclipse.elk.alg.disco/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.disco</artifactId>
   <name>ELK Disconnected Components Compaction</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Compaction algorithms for disconnected graphs.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.force/pom.xml
+++ b/plugins/org.eclipse.elk.alg.force/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.force</artifactId>
   <name>ELK Force Layout Algorithm</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Layout algorithm based on the force approach.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.graphviz.dot/pom.xml
+++ b/plugins/org.eclipse.elk.alg.graphviz.dot/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.graphviz.dot</artifactId>
   <name>ELK Graphviz Dot Language Parser</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Support for the Graphviz Dot language.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/pom.xml
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.graphviz.layouter</artifactId>
   <name>ELK Layout Bridge for Graphviz</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Bridge to the Graphviz command-line tool for access through ELK.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.layered/pom.xml
+++ b/plugins/org.eclipse.elk.alg.layered/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.layered</artifactId>
   <name>ELK Layered Layout Algorithm</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Layout algorithm based on the layered approach.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.mrtree/pom.xml
+++ b/plugins/org.eclipse.elk.alg.mrtree/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.mrtree</artifactId>
   <name>ELK Mr. Tree Layout Algorithm</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Layout algorithm based on the tree approach.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.radial/pom.xml
+++ b/plugins/org.eclipse.elk.alg.radial/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.radial</artifactId>
   <name>ELK Radial Layout Algorithm</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Layout algorithm based on the radial tree approach.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.rectpacking/pom.xml
+++ b/plugins/org.eclipse.elk.alg.rectpacking/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.rectpacking</artifactId>
   <name>ELK Rectangle Packing Algorithm</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Algorithm that views nodes as rectanlges and packs them.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.spore/pom.xml
+++ b/plugins/org.eclipse.elk.alg.spore/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.spore</artifactId>
   <name>ELK SPOrE</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Algorithms for stable compaction and node overlap removal.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.alg.topdownpacking/pom.xml
+++ b/plugins/org.eclipse.elk.alg.topdownpacking/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.topdownpacking</artifactId>
   <name>ELK Topdown Packing Algorithm</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Algorithm that packs nodes into a grid. Used for topdown layout.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.conn.gmf/pom.xml
+++ b/plugins/org.eclipse.elk.conn.gmf/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.conn.gmf</artifactId>
   <name>ELK Layout Connector for GMF</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.debug.grandom.ide/pom.xml
+++ b/plugins/org.eclipse.elk.core.debug.grandom.ide/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.debug.grandom.ide</artifactId>
   <name>ELK Random Graph Generator Generic IDE Services</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.debug.grandom.ui/pom.xml
+++ b/plugins/org.eclipse.elk.core.debug.grandom.ui/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.debug.grandom.ui</artifactId>
   <name>ELK Random Graph Generator UI</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.debug.grandom/pom.xml
+++ b/plugins/org.eclipse.elk.core.debug.grandom/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.debug.grandom</artifactId>
   <name>ELK Random Graph Generator</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.debug/pom.xml
+++ b/plugins/org.eclipse.elk.core.debug/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.debug</artifactId>
   <name>ELK Debugging Utilities</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.meta.ui/pom.xml
+++ b/plugins/org.eclipse.elk.core.meta.ui/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.meta.ui</artifactId>
   <name>ELK Layout Meta Data Language (UI Components)</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core.meta/pom.xml
+++ b/plugins/org.eclipse.elk.core.meta/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.meta</artifactId>
   <name>ELK Layout Meta Data Language</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>The Layout Meta Data Language describes layout algorithms and their configuration options.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.core.service/pom.xml
+++ b/plugins/org.eclipse.elk.core.service/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.service</artifactId>
   <name>ELK Layout Service Layer</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>ELK Service integrates layout computations into Eclipse-based IDEs (async execution, progress reporting, etc.).</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.core.ui/pom.xml
+++ b/plugins/org.eclipse.elk.core.ui/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.ui</artifactId>
   <name>ELK Core Components (UI)</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.core/pom.xml
+++ b/plugins/org.eclipse.elk.core/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core</artifactId>
   <name>ELK Core Components</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>The Core of the Eclipse Layout Kernel.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.graph.json.text.ide/pom.xml
+++ b/plugins/org.eclipse.elk.graph.json.text.ide/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.json.text.ide</artifactId>
   <name>ELK Textual JSON Graph Format Generic IDE Services</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Generic IDE Services for the textual ELK JSON Graph format.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.graph.json.text.ui/pom.xml
+++ b/plugins/org.eclipse.elk.graph.json.text.ui/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.json.text.ui</artifactId>
   <name>ELK Textual JSON Graph Format UI</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.graph.json.text/pom.xml
+++ b/plugins/org.eclipse.elk.graph.json.text/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.json.text</artifactId>
   <name>ELK Textual JSON Graph Format</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>An Xtext language for the JSON ELK Graph data structure.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.graph.json/pom.xml
+++ b/plugins/org.eclipse.elk.graph.json/pom.xml
@@ -17,11 +17,9 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.json</artifactId>
   <name>ELK Graph JSON</name>
   <description>JSON Format of the ELK Graph</description>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <dependencies>

--- a/plugins/org.eclipse.elk.graph.text.ide/pom.xml
+++ b/plugins/org.eclipse.elk.graph.text.ide/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.text.ide</artifactId>
   <name>ELK Textual Graph Format Generic IDE Services</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>Generic IDE Services for the textual ELK Graph format.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.graph.text.ui/pom.xml
+++ b/plugins/org.eclipse.elk.graph.text.ui/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.text.ui</artifactId>
   <name>ELK Textual Graph Format UI</name>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/plugins/org.eclipse.elk.graph.text/pom.xml
+++ b/plugins/org.eclipse.elk.graph.text/pom.xml
@@ -17,10 +17,8 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.text</artifactId>
   <name>ELK Textual Graph Format</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>An Xtext language for the ELK Graph data structure.</description>
   <packaging>eclipse-plugin</packaging>
 

--- a/plugins/org.eclipse.elk.graph/pom.xml
+++ b/plugins/org.eclipse.elk.graph/pom.xml
@@ -35,10 +35,8 @@
     </dependency>
   </dependencies>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph</artifactId>
   <name>ELK Graph Model</name>
-  <version>0.10.0-SNAPSHOT</version>
   <description>The ELK Graph is the central data structure of the Eclipse Layout Kernel.</description>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -9,9 +9,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>plugins</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>

--- a/test/org.eclipse.elk.alg.common.test/pom.xml
+++ b/test/org.eclipse.elk.alg.common.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.common.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.disco.test/pom.xml
+++ b/test/org.eclipse.elk.alg.disco.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.disco.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.force.test/pom.xml
+++ b/test/org.eclipse.elk.alg.force.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.force.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.layered.test/pom.xml
+++ b/test/org.eclipse.elk.alg.layered.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.layered.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.mrtree.test/pom.xml
+++ b/test/org.eclipse.elk.alg.mrtree.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.mrtree.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.radial.test/pom.xml
+++ b/test/org.eclipse.elk.alg.radial.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.radial.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.rectpacking.test/pom.xml
+++ b/test/org.eclipse.elk.alg.rectpacking.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.rectpacking.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.spore.test/pom.xml
+++ b/test/org.eclipse.elk.alg.spore.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.spore.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.test/pom.xml
+++ b/test/org.eclipse.elk.alg.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.alg.topdown.test/pom.xml
+++ b/test/org.eclipse.elk.alg.topdown.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.alg.topdown.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.core.test/pom.xml
+++ b/test/org.eclipse.elk.core.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.core.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.graph.json.test/pom.xml
+++ b/test/org.eclipse.elk.graph.json.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.json.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.graph.test/pom.xml
+++ b/test/org.eclipse.elk.graph.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.graph.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/org.eclipse.elk.shared.test/pom.xml
+++ b/test/org.eclipse.elk.shared.test/pom.xml
@@ -18,9 +18,7 @@
     <relativePath>../../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>org.eclipse.elk.shared.test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <build>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -9,9 +9,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.eclipse.elk</groupId>
   <artifactId>test</artifactId>
-  <version>0.10.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>


### PR DESCRIPTION
The group id and version of modules are not necessary if they are the same as in the parent. Maven best practice is to omit them in a reactor where every module has the same version.

The target platform has been left out of this change, as another PR will remove the related pom.xml there.