### PR TITLE
bump node version for tests

### DIFF
--- a/.github/workflows/elkjs.yml
+++ b/.github/workflows/elkjs.yml
@@ -15,7 +15,7 @@ jobs:
         # 11  - LTS 
         # 17 - LTS
         java-version: [ 11, 17 ]
-        node-version: [ 12.x, 18.x ]
+        node-version: [ 18.x, 20.x ]
 
     steps:
     # Checkout the repository of both elk and elkjs, place them next to each other. 

--- a/.github/workflows/elkjs.yml
+++ b/.github/workflows/elkjs.yml
@@ -12,10 +12,9 @@ jobs:
     strategy:
       matrix:
         # We check against LTSs supported by GWT
-        # 11  - LTS 
         # 17 - LTS
-        node-version: [ 14.x, 16.x, 18.x, 20.x, 22.x ]
-        java-version: [ 11, 13, 15, 17 ] 
+        node-version: [ 14.x, 22.x ]
+        java-version: [ 17 ] 
 
     steps:
     # Checkout the repository of both elk and elkjs, place them next to each other. 

--- a/.github/workflows/elkjs.yml
+++ b/.github/workflows/elkjs.yml
@@ -14,7 +14,7 @@ jobs:
         # We check against LTSs supported by GWT
         # 11  - LTS 
         # 17 - LTS
-        node-version: [ 14.x, 16.x, 18.x ]
+        node-version: [ 14.x, 16.x, 18.x, 20.x, 22.x ]
         java-version: [ 11, 13, 15, 17 ] 
 
     steps:

--- a/.github/workflows/elkjs.yml
+++ b/.github/workflows/elkjs.yml
@@ -14,8 +14,8 @@ jobs:
         # We check against LTSs supported by GWT
         # 11  - LTS 
         # 17 - LTS
-        java-version: [ 11, 17 ]
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 14.x, 16.x, 18.x ]
+        java-version: [ 11, 13, 15, 17 ] 
 
     steps:
     # Checkout the repository of both elk and elkjs, place them next to each other. 


### PR DESCRIPTION
once https://github.com/kieler/elkjs/pull/323 is merged the checks for this PR can be rerun and should pass

updates the node versions that we test for elkjs to be on par with the ones elkjs itself builds against