### PR TITLE
libavoidCancelRouting: Cancel Routing programmatically

### DIFF
--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidLayoutProvider.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/LibavoidLayoutProvider.java
@@ -32,6 +32,8 @@ import org.eclipse.elk.graph.ElkPort;
  * @author uru
  */
 public class LibavoidLayoutProvider extends AbstractLayoutProvider {
+    
+    private final List<LibavoidServer> activeLibavoidServerList = new ArrayList<>();
 
     private LibavoidServerCommunicator comm = new LibavoidServerCommunicator();
 
@@ -54,8 +56,10 @@ public class LibavoidLayoutProvider extends AbstractLayoutProvider {
         
         // create an Libavoid server process instance or use an existing one
         LibavoidServer lvServer = LibavoidServerPool.INSTANCE.fetch();
+        this.activeLibavoidServerList.add(lvServer);
         // send a layout request to the server process and apply the layout
         comm.requestLayout(parentNode, progressMonitor, lvServer);
+        this.activeLqibavoidServerList.remove(lvServer);
         // if everything worked well, release the used process instance
         LibavoidServerPool.INSTANCE.release(lvServer);
 
@@ -75,6 +79,10 @@ public class LibavoidLayoutProvider extends AbstractLayoutProvider {
     			
     		}
     	}
+    }
+    
+    public List<LibavoidServer> getActiveLibavoidServers() {
+        return this.activeLibavoidServerList;
     }
 
 }

--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
@@ -454,6 +454,15 @@ public class LibavoidServer {
         }
         error.append('.');
     }
+    
+    /** interrupt Server process early **/
+    public void cancelEarly() {
+        Process myProcess = process;
+        if (myProcess != null && myProcess.isAlive()) {
+            libavoidStream = null;
+            myProcess.destroy();
+        }
+    }
 
     /** default timeout for waiting for the server to give some output. */
     public static final int PROCESS_DEF_TIMEOUT = 10000;


### PR DESCRIPTION
This change exposes the list of running libavoid servers as well as adds a possibility to cancel a running server from outside of the class.