### PR TITLE
libavoidCancelRouting: Add a method that enables canceling of a started layout operation with libavoid

### DIFF
--- a/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
+++ b/plugins/org.eclipse.elk.alg.libavoid/src/org/eclipse/elk/alg/libavoid/server/LibavoidServer.java
@@ -455,6 +455,17 @@ public class LibavoidServer {
         error.append('.');
     }
 
+    /** interrupt Server operation */
+    public void cancelProcess() {
+        synchronized (nextJob) {
+            Process myProcess = process;
+            if (myProcess != null) {
+                libavoidStream = null;
+                myProcess.destroy();
+            }
+        }
+    }
+
     /** default timeout for waiting for the server to give some output. */
     public static final int PROCESS_DEF_TIMEOUT = 10000;
 
@@ -496,14 +507,7 @@ public class LibavoidServer {
                 }
 
                 if (!interrupted) {
-                    synchronized (nextJob) {
-                        // timeout has occurred! kill the process so the main thread will wake
-                        Process myProcess = process;
-                        if (myProcess != null) {
-                            libavoidStream = null;
-                            myProcess.destroy();
-                        }
-                    }
+                    cancelProcess();
                 }
 
             } while (watchdog == this);


### PR DESCRIPTION
**Description** 
Large diagrams can take a significant amount of time (more than 1 minute) to complete layout with libavoid. During this process, there is currently no way to cancel the operation. This pull request introduces a minimally invasive change that enables programmatic cancellation of an ongoing layout operation. Please let me know if:

- This aligns with your design choices.
- This PR meets the expectations for how such a change should be implemented.

**Other Considerations**
The PR includes minimal code changes and replicates the existing logic used to close a libavoid server, which the watchdog would use to stop the server if the timeout is exceeded.
A more elegant solution would be to cancel the layout operation via a progress monitor. However, since this change only affects libavoid and would require modifications to elk-core, I determined that this approach is less invasive and likely more in line with your interests.