### PR TITLE
Update RELEASE.md

### DIFF
--- a/build/RELEASE.md
+++ b/build/RELEASE.md
@@ -24,7 +24,6 @@ The Eclipse release process is described in more detail in the [Eclipse Project 
       Update site for the Eclipse Layout Kernel, version VERSION_NUMBER.
     </description>
     ```
-1. Remove the `Website` stage's call to the `publish-website.sh` script from the release build's `Jenkinsfile` and configure the build variables in the [Jenkins configuration](https://ci.eclipse.org/elk/job/IntegrationNightly/):
 
    
     Variable              | New value


### PR DESCRIPTION
Remove instruction to remove website stage from Jenkinsfile.

It turns out Jenkins always uses the Jenkinsfile from the master branch, so removing the call on the release branch doesn't even have any effect. 

This PR serves as a discussion starting point for how we would like to handle this in the future.