### PR TITLE
correct targetplatform to use correct orbit release for eclipse 24-09

### DIFF
--- a/build/org.eclipse.elk.targetplatform/org.eclipse.elk.targetplatform.target
+++ b/build/org.eclipse.elk.targetplatform/org.eclipse.elk.targetplatform.target
@@ -14,7 +14,7 @@
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.hamcrest.library" version="0.0.0"/>
       <unit id="com.google.gson" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.32.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.33.0"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
The wrong orbit release was used in the target platform, but it doesn't seem to break anything. We should fix this inconsistency anyway.