### PR TITLE
graphviz.layouter: Making the graphiz executable timeout editable during runtime for non-eclipse user

### DIFF
--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizTool.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/GraphvizTool.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.List;
 
 import org.eclipse.elk.alg.graphviz.dot.transform.Command;
@@ -54,7 +55,7 @@ public class GraphvizTool {
     /** preference constant for timeout. */
     public static final String PREF_TIMEOUT = "graphviz.timeout";
     /** default timeout for waiting for Graphviz to give some output. */
-    public static final int PROCESS_DEF_TIMEOUT = 20000;
+    public static final AtomicInteger PROCESS_DEF_TIMEOUT = new AtomicInteger(20000);
     /** minimal timeout for waiting for Graphviz to give some output. */
     public static final int PROCESS_MIN_TIMEOUT = 200;
     
@@ -546,7 +547,7 @@ public class GraphvizTool {
                 }
                 
                 // retrieve the current timeout value
-                int timeout = PROCESS_DEF_TIMEOUT;
+                int timeout = PROCESS_DEF_TIMEOUT.get();
                 if (EclipseRuntimeDetector.isEclipseRunning()) {
                     int timeoutPreference =
                             GraphvizLayouterPreferenceStoreAccess.getUISaveInt(PREF_TIMEOUT);
@@ -554,7 +555,7 @@ public class GraphvizTool {
                         timeout = timeoutPreference;
                     }
                 }
-                
+
                 boolean interrupted = false;
                 try {
                     Thread.sleep(timeout);

--- a/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/preferences/GraphvizLayouterPreferenceInitializer.java
+++ b/plugins/org.eclipse.elk.alg.graphviz.layouter/src/org/eclipse/elk/alg/graphviz/layouter/preferences/GraphvizLayouterPreferenceInitializer.java
@@ -26,7 +26,7 @@ public class GraphvizLayouterPreferenceInitializer extends AbstractPreferenceIni
     public void initializeDefaultPreferences() {
         IPreferenceStore store = GraphvizLayouterPreferenceStore.getInstance().getPreferenceStore();
 
-        store.setDefault(GraphvizTool.PREF_TIMEOUT, GraphvizTool.PROCESS_DEF_TIMEOUT);
+        store.setDefault(GraphvizTool.PREF_TIMEOUT, GraphvizTool.PROCESS_DEF_TIMEOUT.get());
         store.setDefault(GraphvizLayoutProvider.PREF_GRAPHVIZ_REUSE_PROCESS,
                 GraphvizLayoutProvider.REUSE_PROCESS_DEFAULT);
     }


### PR DESCRIPTION
Replaces the `PROCESS_DEF_TIMEOUT` attribute in the `GraphvizTool` class (changing it from a primitive `int` to `AtomicInteger`) to allow dynamic reconfiguration of the Graphviz executable timeout.

This provides flexibility, especially for users outside an Eclipse environment, while ensuring the modification remains thread-safe.