### PR TITLE
new config for migration to central

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -119,6 +119,7 @@
 	      <publishingServerId>central</publishingServerId>
 	      <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
+              <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
 	    </configuration>
 	  </plugin>
           <!-- Create GPG signatures. -->

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -110,6 +110,17 @@
       </distributionManagement>
       <build>
         <plugins>
+	  <plugin>
+	    <groupId>org.sonatype.central</groupId>
+	    <artifactId>central-publishing-maven-plugin</artifactId>
+	    <version>0.8.0</version>
+	    <extensions>true</extensions>
+	    <configuration>
+	      <publishingServerId>central</publishingServerId>
+	      <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+	    </configuration>
+	  </plugin>
           <!-- Create GPG signatures. -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
this is following the guide by eclipse: https://eclipse-cbi.github.io/cbi-website/best-practices/github-actions/central-portal/index.html

(not sure if we want autopublish? they list it as best practice)

I think we may still have to add the otterdog config described in there