### PR TITLE
Only reorder ports on parent if they changed.

### DIFF
--- a/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
+++ b/plugins/org.eclipse.elk.alg.layered/src/org/eclipse/elk/alg/layered/p3order/LayerSweepCrossingMinimizer.java
@@ -154,7 +154,7 @@ public class LayerSweepCrossingMinimizer
     }
 
     private void setPortOrderOnParentGraph(final GraphInfoHolder gData) {
-        if (gData.hasExternalPorts()) {
+        if (gData.hasExternalPorts() && gData.getBestSweep() != null) {
             SweepCopy bestSweep = gData.getBestSweep();
             // Sort ports on left and right side of the parent node
             sortPortsByDummyPositionsInLastLayer(bestSweep.nodes(), gData.parent(), true);


### PR DESCRIPTION
This issue does only seem to surface once model order allows us to just use the initial graph without changing it.

Fixes #968 